### PR TITLE
[Fix] Add dropdowns for OS versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Selecciona Sistema Operativo</title>
+</head>
+<body>
+    <h1>Versiones de Windows</h1>
+    <select name="windows">
+        <option value="win11">Windows 11</option>
+        <option value="win10">Windows 10</option>
+        <option value="win8">Windows 8</option>
+        <option value="win7">Windows 7</option>
+        <option value="winxp">Windows XP</option>
+    </select>
+
+    <h1>Distribuciones de Linux</h1>
+    <select name="linux">
+        <option value="ubuntu">Ubuntu</option>
+        <option value="debian">Debian</option>
+        <option value="fedora">Fedora</option>
+        <option value="arch">Arch Linux</option>
+        <option value="opensuse">openSUSE</option>
+    </select>
+</body>
+</html>


### PR DESCRIPTION
Added a new `index.html` file with dropdown menus listing several Windows versions and popular Linux distributions.

### Testing Done
- `flake8` not installed
- `pytest` reported `tests/` missing

------
https://chatgpt.com/codex/tasks/task_e_6840ce8341a883209cb25804feef6374